### PR TITLE
feat: add travel reimbursement to registration

### DIFF
--- a/hackportal.config.ts
+++ b/hackportal.config.ts
@@ -371,6 +371,23 @@ export const hackPortalConfig: HackPortalConfig = {
               },
             ],
           },
+          {
+            question: 'Are you interested in travel reimbursement?',
+            required: true,
+            id: 'travel_reimbursement',
+            name: 'travel_reimbursement',
+            initialValue: 'no',
+            options: [
+              {
+                title: 'Yes',
+                value: 'yes',
+              },
+              {
+                title: 'No',
+                value: 'no',
+              },
+            ],
+          },
         ],
       },
       {


### PR DESCRIPTION
Is adding travel reimbursement to the registration page enough or does there need to be an option on the profile page?